### PR TITLE
Check for updates using the Github API instead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ msgpack_python
 packaging
 Pillow
 requests
+semver

--- a/s3s.py
+++ b/s3s.py
@@ -590,7 +590,7 @@ def check_for_updates():
 	response = requests.get("https://api.github.com/repos/frozenpandaman/s3s/releases/latest")
 	try:
 		repo_version = response.json()["tag_name"]
-		# Returns -1 if the repo has a newer version
+		# Returns a negative number if the repo has a newer version
 		if semver.compare(A_VERSION, repo_version) < 0:
 			print(f"\nThere is a new version ({repo_version}) available.")
 			print("\nGo to https://github.com/frozenpandaman/s3s/releases/latest to download it.")

--- a/s3s.py
+++ b/s3s.py
@@ -7,6 +7,7 @@
 import sys, os, requests, json, time, datetime, argparse, msgpack
 from PIL import Image, ImageDraw
 from packaging import version
+import semver
 import iksm
 
 A_VERSION = "0.0.3"
@@ -584,9 +585,16 @@ def post_result(data, isblackout, istestrun):
 
 def check_for_updates():
 	'''Checks the script version against the repo, reminding users to update if available.'''
-
-	print("Auto-update is not yet implemented. Please update the script regularly with `git pull`.")
-	# TODO
+	print("\nChecking for updates...")
+	response = requests.get("https://api.github.com/repos/frozenpandaman/s3s/releases/latest")
+	try:
+		repo_version = response.json()["tag_name"]
+		# Returns -1 if the repo has a newer version
+		if semver.compare(A_VERSION, repo_version) == -1:
+			print(f"\nThere is a new version ({repo_version}) available.")
+			print("\nGo to https://github.com/frozenpandaman/s3s/releases/latest to download it.")
+	except:
+		print(f"\nCould not get the latest version. (Status Code {response.status_code})")
 
 
 def check_statink_key():

--- a/s3s.py
+++ b/s3s.py
@@ -591,7 +591,7 @@ def check_for_updates():
 	try:
 		repo_version = response.json()["tag_name"]
 		# Returns -1 if the repo has a newer version
-		if semver.compare(A_VERSION, repo_version) == -1:
+		if semver.compare(A_VERSION, repo_version) < 0:
 			print(f"\nThere is a new version ({repo_version}) available.")
 			print("\nGo to https://github.com/frozenpandaman/s3s/releases/latest to download it.")
 	except:


### PR DESCRIPTION
I saw in #13 that you aren't going to add this part until v0.1.0, So when that comes I thought it was much more practical to use the github api to check for updates. What I wrote in this PR is very basic and could be expanded on for e.g. better error handling (I just put a simple try-except lol). What it does basically is checks the url and gets the `tag_name` json value from it which holds the latest version number. I also added [semver](https://pypi.org/project/semver/) as a dependency for easy version comparison (it's only a 12kb package) but lmk if you would rather not do that.