### PR TITLE
use shutil.get_terminal_size() instead of os.get_terminal_size()

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -4,7 +4,7 @@
 # https://github.com/frozenpandaman/s3s
 # License: GPLv3
 
-import argparse, datetime, json, os, re, requests, sys, time, uuid
+import argparse, datetime, json, os, shutil, re, requests, sys, time, uuid
 import msgpack
 from packaging import version
 from PIL import Image
@@ -1008,7 +1008,7 @@ class SquidProgress:
         self.count = 0
 
     def __call__(self):
-        lineend = os.get_terminal_size()[0] - 4
+        lineend = shutil.get_terminal_size()[0] - 4
         ika = '>=> ' if self.count % 2 == 0 else '===>'
         sys.stdout.write(f"\r{' '*self.count}{ika}{' '*(lineend - self.count)}")
         sys.stdout.flush()

--- a/s3s.py
+++ b/s3s.py
@@ -1004,17 +1004,23 @@ def monitor_battles(which, secs, isblackout, istestrun):
 		print("Bye!")
 
 class SquidProgress:
-    def __init__(self):
-        self.count = 0
+	'''Display animation while waiting.'''
 
-    def __call__(self):
-        lineend = shutil.get_terminal_size()[0] - 4
-        ika = '>=> ' if self.count % 2 == 0 else '===>'
-        sys.stdout.write(f"\r{' '*self.count}{ika}{' '*(lineend - self.count)}")
-        sys.stdout.flush()
-        self.count += 1
-        if self.count > lineend:
-            self.count = 0
+	def __init__(self):
+		self.count = 0
+
+	def __call__(self):
+		lineend = shutil.get_terminal_size()[0] - 5 # 5 = ('>=> ' or '===>') + blank 1
+		ika = '>=> ' if self.count % 2 == 0 else '===>'
+		sys.stdout.write(f"\r{' '*self.count}{ika}{' '*(lineend - self.count)}")
+		sys.stdout.flush()
+		self.count += 1
+		if self.count > lineend:
+			self.count = 0
+
+	def __del__(self):
+		sys.stdout.write(f"\r{' '*(os.get_terminal_size()[0] - 1)}\r")
+		sys.stdout.flush()
 
 def main():
 	'''Main process, including I/O and setup.'''


### PR DESCRIPTION
### Summary
- The python command `os.get_terminal_size()` - which is called to animate the little squid during the loading event - does not work in many situations (i.e. when python gets called from a java app or from terminals which don't support telling python their size)
- in such a situation, `os.get_terminal_size()` will simply throw an exception which does not get caught and therefore causes the whole script to crash, completely preventing the user from downloading matches.
- in these cases, `shutil.get_terminal_size()` is a high level alternative providing a fallback, allowing to still use the script by simply defaulting a terminal size of 80x24 whenever the environment does no support telling python the size of the terminal.
- [the documentation for `os.get_terminal_size()`](https://docs.python.org/3/library/os.html#querying-the-size-of-a-terminal) especially states that `shutil.get_terminal_size()` should normally be used

I hope it's ok to directly send a pull request without opening an issue first. I figured I might as well directly open a pull request because it's such a small change. 
Of course I can also still open an issue if you want me to.

### My specific use case
I use the s3s script in a very specific way:
I have a java application which needs access to SplatNet 3 to download my match summaries into a local database once per hour. It runs the s3s script before "stealing" the tokens from the s3s config file to make sure those tokens are valid and fresh.  
However, in this specific situation there is no terminal involved, the whole standard output gets read programmatically. This means `os.get_terminal_size()` will always throw an exception and therefore the s3s script will always crash if my java application starts it. Another use case which doesn't work with `os.get_terminal_size()` is executing the script via the good old Windows cmd (haven't checked powershell, but cmd does not work).

I'm not a python programmer so I can't speak about possible side effects but switching to `shutil` fixed the issue for me.