### PR TITLE
check http status code first, then parse the response contents

### DIFF
--- a/iksm.py
+++ b/iksm.py
@@ -323,7 +323,7 @@ def get_bullet(web_service_token, web_view_ver, app_user_agent, user_lang, user_
 	except (json.decoder.JSONDecodeError, TypeError):
 		print("Got non-JSON response from Nintendo.")
 		sys.exit(1)
-	except KeyError:
+	except:
 		print("Error from Nintendo (in api/bullet_tokens step):")
 		print(json.dumps(bullet_resp, indent=2))
 		sys.exit(1)

--- a/iksm.py
+++ b/iksm.py
@@ -306,7 +306,6 @@ def get_bullet(web_service_token, web_view_ver, app_user_agent, user_lang, user_
 	}
 	url = "https://api.lp1.av5ja.srv.nintendo.net/api/bullet_tokens"
 	r = requests.post(url, headers=app_head, cookies=app_cookies)
-	bullet_resp = json.loads(r.text)
 
 	if r.status_code == 401:
 		print("Unauthorized error (ERROR_INVALID_GAME_WEB_TOKEN). Cannot fetch tokens at this time.")
@@ -317,13 +316,14 @@ def get_bullet(web_service_token, web_view_ver, app_user_agent, user_lang, user_
 	elif r.status_code == 204: # No Content, USER_NOT_REGISTERED
 		print("Cannot access SplatNet 3 without having played online.")
 		sys.exit(1)
-	else:
-		try:
-			bullet_token = bullet_resp["bulletToken"]
-		except:
-			print("Error from Nintendo (in api/bullet_tokens step):")
-			print(json.dumps(bullet_resp, indent=2))
-			sys.exit(1)
+
+	bullet_resp = json.loads(r.text)
+	try:
+		bullet_token = bullet_resp["bulletToken"]
+	except:
+		print("Error from Nintendo (in api/bullet_tokens step):")
+		print(json.dumps(bullet_resp, indent=2))
+		sys.exit(1)
 
 	return bullet_token
 

--- a/iksm.py
+++ b/iksm.py
@@ -317,10 +317,13 @@ def get_bullet(web_service_token, web_view_ver, app_user_agent, user_lang, user_
 		print("Cannot access SplatNet 3 without having played online.")
 		sys.exit(1)
 
-	bullet_resp = json.loads(r.text)
 	try:
+		bullet_resp = json.loads(r.text)
 		bullet_token = bullet_resp["bulletToken"]
-	except:
+	except (json.decoder.JSONDecodeError, TypeError):
+		print("Got non-JSON response from Nintendo.")
+		sys.exit(1)
+	except KeyError:
 		print("Error from Nintendo (in api/bullet_tokens step):")
 		print(json.dumps(bullet_resp, indent=2))
 		sys.exit(1)


### PR DESCRIPTION
When `r.status_code==204`, `r.text==''`.
Parsing the empty string '' will result in a json error.

```py
>>> import json
>>> json.loads('')
Traceback (most recent call last):
  File "E:\dev\Python310\lib\code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "E:\dev\Python310\lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "E:\dev\Python310\lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "E:\dev\Python310\lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```