### PR TITLE
stat.ink API key input now can be cancelled

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -768,12 +768,16 @@ def check_statink_key():
 	elif len(API_KEY) != 43:
 		new_api_key = ""
 		while len(new_api_key.strip()) != 43 and new_api_key.strip() != "skip":
-			if new_api_key.strip() == "" and API_KEY.strip() == "":
-				new_api_key = input("stat.ink API key: ")
-			else:
-				print("Invalid stat.ink API key. Please re-enter it below.")
-				new_api_key = input("stat.ink API key: ")
-			CONFIG_DATA["api_key"] = new_api_key
+			try:
+				if new_api_key.strip() == "" and API_KEY.strip() == "":
+					new_api_key = input("stat.ink API key: ")
+				else:
+					print("Invalid stat.ink API key. Please re-enter it below.")
+					new_api_key = input("stat.ink API key: ")
+				CONFIG_DATA["api_key"] = new_api_key
+			except KeyboardInterrupt:
+				print("Cancelled API key input.")
+				sys.exit(0)
 		write_config(CONFIG_DATA)
 	return
 


### PR DESCRIPTION
Hi, firstly I'd like to say, I'm very appreciated you created such a nice tool for Splatoon 3 as well.

I'm unofficially containerizing this app here: https://github.com/issei-m/s3s-docker and facing on a very minor problem there.
The current version of s3s.py doesn't trap SIGINT during while loop to wait for user to input stat.ink API key, so containerized version of the app behaves like getting hang-up (the container doesn't shut down) when a user hits CTRL-C against docker run.

So I want the app to handle the signal correctly. Could you consider it? 
Thank you.
