### PR TITLE
Record played time and skip fetched results

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -223,8 +223,8 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 
 	needs_sorted = False # https://ygdp.yale.edu/phenomena/needs-washed :D
 
-	last_played_time = datetime.datetime.fromisoformat(LAST_PLAYED_TIME)
-	latest_played_time = datetime.datetime.fromisoformat(LAST_PLAYED_TIME)
+	last_played_time = utils.epoch_time(LAST_PLAYED_TIME)
+	latest_played_time = utils.epoch_time(LAST_PLAYED_TIME)
 
 	for sha in queries:
 		if sha is not None:
@@ -241,7 +241,7 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 			if "latestBattleHistories" in query1_resp["data"]:
 				for battle_group in query1_resp["data"]["latestBattleHistories"]["historyGroups"]["nodes"]:
 					for battle in battle_group["historyDetails"]["nodes"]:
-						played_time = datetime.datetime.fromisoformat(battle["playedTime"].replace("Z", "+00:00"))
+						played_time = utils.epoch_time(battle["playedTime"])
 						if played_time <= last_played_time:
 							continue
 						if played_time > latest_played_time:
@@ -300,7 +300,7 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 							headers=headbutt(),
 							cookies=dict(_gtoken=GTOKEN))
 						query2_resp_b = json.loads(query2_b.text)
-						played_time = datetime.datetime.fromisoformat(query2_resp_b["data"]["vsHistoryDetail"]["playedTime"].replace("Z", "+00:00"))
+						played_time = utils.epoch_time(query2_resp_b["data"]["vsHistoryDetail"]["playedTime"])
 						if played_time <= last_played_time:
 							break
 						if played_time > latest_played_time:
@@ -314,7 +314,7 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 						headers=headbutt(),
 						cookies=dict(_gtoken=GTOKEN))
 					query2_resp_j = json.loads(query2_j.text)
-					played_time = datetime.datetime.fromisoformat(query2_resp_j["data"]["coopHistoryDetail"]["playedTime"].replace("Z", "+00:00"))
+					played_time = utils.epoch_time(query2_resp_j["data"]["coopHistoryDetail"]["playedTime"])
 					if played_time <= last_played_time:
 						break
 					if played_time > latest_played_time:

--- a/s3s.py
+++ b/s3s.py
@@ -194,10 +194,9 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 	swim()
 
 	last_export_time = 0
-	last_played_time = 0
-	if record_time:
-		if "last_export_time" in CONFIG_DATA:
-			last_export_time = CONFIG_DATA["last_export_time"]
+	if record_time and "last_export_time" in CONFIG_DATA:
+		last_export_time = CONFIG_DATA["last_export_time"]
+	last_played_time = last_export_time
 
 	ink_list, salmon_list = [], []
 	parent_files = []
@@ -334,7 +333,7 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 		else: # sha = None (we don't want to get the specified result type)
 			pass
 
-	if record_time and last_export_time != last_played_time:
+	if record_time:
 		CONFIG_DATA["last_export_time"] = last_played_time
 		write_config(CONFIG_DATA)
 

--- a/s3s.py
+++ b/s3s.py
@@ -193,11 +193,11 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 			print("* prefetch_checks() succeeded")
 	swim()
 
+	last_export_time = 0
 	last_played_time = 0
-	latest_played_time = 0
 	if record_time:
-		if "last_played_time" in CONFIG_DATA:
-			last_played_time = CONFIG_DATA["last_played_time"]
+		if "last_export_time" in CONFIG_DATA:
+			last_export_time = CONFIG_DATA["last_export_time"]
 
 	ink_list, salmon_list = [], []
 	parent_files = []
@@ -239,10 +239,10 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 				for battle_group in query1_resp["data"]["latestBattleHistories"]["historyGroups"]["nodes"]:
 					for battle in battle_group["historyDetails"]["nodes"]:
 						played_time = utils.epoch_time(battle["playedTime"])
-						if played_time <= last_played_time:
+						if played_time <= last_export_time:
 							continue
-						if played_time > latest_played_time:
-							latest_played_time = played_time
+						if played_time > last_played_time:
+							last_played_time = played_time
 						battle_ids.append(battle["id"]) # don't filter out private battles here - do that in post_result()
 
 			# ink battles - latest 50 turf war
@@ -298,10 +298,10 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 							cookies=dict(_gtoken=GTOKEN))
 						query2_resp_b = json.loads(query2_b.text)
 						played_time = utils.epoch_time(query2_resp_b["data"]["vsHistoryDetail"]["playedTime"])
-						if played_time <= last_played_time:
+						if played_time <= last_export_time:
 							break
-						if played_time > latest_played_time:
-							latest_played_time = played_time
+						if played_time > last_played_time:
+							last_played_time = played_time
 						ink_list.append(query2_resp_b)
 						swim()
 
@@ -312,10 +312,10 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 						cookies=dict(_gtoken=GTOKEN))
 					query2_resp_j = json.loads(query2_j.text)
 					played_time = utils.epoch_time(query2_resp_j["data"]["coopHistoryDetail"]["playedTime"])
-					if played_time <= last_played_time:
+					if played_time <= last_export_time:
 						break
-					if played_time > latest_played_time:
-						latest_played_time = played_time
+					if played_time > last_played_time:
+						last_played_time = played_time
 					salmon_list.append(query2_resp_j)
 					swim()
 
@@ -334,8 +334,8 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 		else: # sha = None (we don't want to get the specified result type)
 			pass
 
-	if record_time and last_played_time != latest_played_time:
-		CONFIG_DATA["last_played_time"] = latest_played_time
+	if record_time and last_export_time != last_played_time:
+		CONFIG_DATA["last_export_time"] = last_played_time
 		write_config(CONFIG_DATA)
 
 	if exportall:

--- a/s3s.py
+++ b/s3s.py
@@ -39,13 +39,13 @@ except (IOError, ValueError):
 	config_file.close()
 
 # SET GLOBALS
-API_KEY          = CONFIG_DATA["api_key"]          # for stat.ink
-USER_LANG        = CONFIG_DATA["acc_loc"][:5]      # user input
-USER_COUNTRY     = CONFIG_DATA["acc_loc"][-2:]     # nintendo account info
-GTOKEN           = CONFIG_DATA["gtoken"]           # for accessing splatnet - base64 json web token
-BULLETTOKEN      = CONFIG_DATA["bullettoken"]      # for accessing splatnet - base64
-SESSION_TOKEN    = CONFIG_DATA["session_token"]    # for nintendo login
-F_GEN_URL        = CONFIG_DATA["f_gen"]            # endpoint for generating f (imink API by default)
+API_KEY       = CONFIG_DATA["api_key"]       # for stat.ink
+USER_LANG     = CONFIG_DATA["acc_loc"][:5]   # user input
+USER_COUNTRY  = CONFIG_DATA["acc_loc"][-2:]  # nintendo account info
+GTOKEN        = CONFIG_DATA["gtoken"]        # for accessing splatnet - base64 json web token
+BULLETTOKEN   = CONFIG_DATA["bullettoken"]   # for accessing splatnet - base64
+SESSION_TOKEN = CONFIG_DATA["session_token"] # for nintendo login
+F_GEN_URL     = CONFIG_DATA["f_gen"]         # endpoint for generating f (imink API by default)
 
 # SET HTTP HEADERS
 DEFAULT_USER_AGENT = 'Mozilla/5.0 (Linux; Android 11; Pixel 5) ' \


### PR DESCRIPTION
The patch wil add a new config field `last_played_time` for recording `playedTime` field of battles and jobs.

When fetching JSON,

- latest battles will be checked during overview phase, so that fetched battles will not be requested again,
- regular battles, anarchy battles, private battles will be checked during detail phase, so there will be only 1 fetched battle will be requested again,
- jobs will be checked during detail phase, so there will be only 1 fetched job will be requested again.

At last, `last_played_time` will be updated and reloaded.
