### PR TITLE
Support different config file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 config.txt
+venv
+.idea
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.txt
 venv
 .idea
 *.pyc
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,17 @@
+# Config files
+####
+
+# Default config file
 config.txt
-venv
-.idea
-*.pyc
+# Extension for alternate config files
 *.json
+
+# Development
+####
+
+# Python bytecode
+*.pyc
+# Virtual Environment
+venv
+# JetBrains IDE Project files
+.idea

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Looking to track your _Splatoon 2_ gameplay? See **[splatnet2statink](https://gi
 
 ## Usage 🐙
 ```
-$ python s3s.py [-M [N]] [-r] [-nsr | -osr]
+$ python s3s.py [-M [N]] [-r] [-nsr | -osr] [-f config_filename.json]
 ```
 
 The `-M` flag runs the script in monitoring mode, uploading new battles/jobs as you play, checking for new results every `N` seconds; if no `N` is provided, it defaults to 300 (5 minutes).
@@ -33,6 +33,8 @@ The `-r` flag checks for & uploads any battles/jobs present on SplatNet 3 that h
 The `-nsr` flag makes Salmon Run jobs **not** be monitored/uploaded. Use this if you're playing Lobby modes only.
 
 The `-osr` flag, conversely, makes **only** Salmon Run jobs be monitored/uploaded. Use this if you're playing at Grizzco only.
+
+The `-f` flag uses a different config filename than the default `config.txt`. Use this for uploading to your kids' or partners' accounts.
 
 <!-- The `--blackout` flag blacks out other players' names on scoreboard result images and in uploaded data. -->
 

--- a/s3s.py
+++ b/s3s.py
@@ -1162,7 +1162,7 @@ def main():
 		try:
 			statink_uploads = json.loads(resp.text)
 		except:
-			print(f"Encountered an error while checking recently-uploaded {noun}. Is stat.ink down?")
+			print(f"Encountered an error while checking recently-uploaded data. Is stat.ink down?")
 			sys.exit(1)
 
 		to_upload = []

--- a/s3s.py
+++ b/s3s.py
@@ -47,7 +47,7 @@ def parse_arguments():
 
 # CONFIG.TXT CREATION
 CONFIG_FILE_NAME = parse_arguments().config
-if getattr(sys, 'frozen', False):  # place config.txt in same directory as script (bundled or not)
+if getattr(sys, 'frozen', False):  # place config file in same directory as script (bundled or not)
 	app_path = os.path.dirname(sys.executable)
 elif __file__:
 	app_path = os.path.dirname(__file__)
@@ -169,7 +169,7 @@ def gen_new_tokens(reason, force=False):
 		elif new_token == "skip":
 			manual_entry = True
 		else:
-			print("\nWrote session_token to config.txt.")
+			print(f"\nWrote session_token to {CONFIG_FILE_NAME}.")
 		CONFIG_DATA["session_token"] = new_token
 		write_config(CONFIG_DATA)
 	elif SESSION_TOKEN == "skip":
@@ -180,7 +180,7 @@ def gen_new_tokens(reason, force=False):
 		new_gtoken, new_bullettoken = iksm.enter_tokens()
 		acc_lang = "en-US"
 		acc_country = "US"
-		print("Using `en-US` for language and `US` for country by default. These can be changed in config.txt.")
+		print(f"Using `en-US` for language and `US` for country by default. These can be changed in {CONFIG_FILE_NAME}.")
 	else:
 		print("Attempting to generate new gtoken and bulletToken...")
 		new_gtoken, acc_name, acc_lang, acc_country = iksm.get_gtoken(F_GEN_URL, SESSION_TOKEN, A_VERSION)
@@ -191,9 +191,9 @@ def gen_new_tokens(reason, force=False):
 	write_config(CONFIG_DATA)
 
 	if manual_entry:
-		print("Wrote tokens to config.txt.\n")
+		print(f"Wrote tokens to {CONFIG_FILE_NAME}.\n")
 	else:
-		print(f"Wrote tokens for {acc_name} to config.txt.\n")
+		print(f"Wrote tokens for {acc_name} to {CONFIG_FILE_NAME}.\n")
 
 
 def fetch_json(which, separate=False, exportall=False, specific=False, numbers_only=False, printout=False, skipprefetch=False):

--- a/s3s.py
+++ b/s3s.py
@@ -39,7 +39,7 @@ def parse_arguments():
 	parser.add_argument("-i", dest="file", nargs=2, required=False,
 						help="upload local results. use `-i results.json overview.json`")
 	parser.add_argument("-f", dest="config", default="config.txt", required=False,
-						help="filename for config file. use `-f my_config.json`")
+						help="filename for config file. use `-f my_config.json` default: config.txt")
 	parser.add_argument("-t", required=False, action="store_true",
 						help="dry run for testing (won't post to stat.ink)")
 	return parser.parse_args()

--- a/s3s.py
+++ b/s3s.py
@@ -982,7 +982,7 @@ def monitor_battles(which, secs, isblackout, istestrun):
 							cookies=dict(_gtoken=GTOKEN))
 						result = json.loads(result_post.text)
 
-						if False and utils.custom_key_exists("ignore_private"): # TODO - how to check for SR private battles?
+						if False and utils.custom_key_exists("ignore_private", CONFIG_DATA): # TODO - how to check for SR private battles?
 							pass
 						else:
 							outcome = "Success" if result["job_result"]["is_clear"] == True else "Failure"

--- a/s3s.py
+++ b/s3s.py
@@ -25,7 +25,10 @@ if getattr(sys, 'frozen', False): # place config.txt in same directory as script
 	app_path = os.path.dirname(sys.executable)
 elif __file__:
 	app_path = os.path.dirname(__file__)
-config_path = os.path.join(app_path, "config.txt")
+else:
+	# No path to the script (probably can't happen) - just use the current directory
+	app_path = None
+config_path = "config.txt" if app_path is None else os.path.join(app_path, "config.txt")
 
 try:
 	config_file = open(config_path, "r")

--- a/s3s.py
+++ b/s3s.py
@@ -20,15 +20,41 @@ os.system("") # ANSI escape setup
 if sys.version_info[1] >= 7: # only works on python 3.7+
 	sys.stdout.reconfigure(encoding='utf-8') # note: please stop using git bash
 
+
+def parse_arguments():
+	parser = argparse.ArgumentParser()
+	srgroup = parser.add_mutually_exclusive_group()
+	parser.add_argument("-M", dest="N", required=False, nargs="?", action="store",
+						help="monitoring mode; pull data every N secs (default: 300)", const=300)
+	parser.add_argument("-r", required=False, action="store_true",
+						help="retroactively post unuploaded battles/jobs")
+	srgroup.add_argument("-nsr", required=False, action="store_true",
+						 help="do not check for Salmon Run jobs")
+	srgroup.add_argument("-osr", required=False, action="store_true",
+						 help="only check for Salmon Run jobs")
+	# parser.add_argument("--blackout", required=False, action="store_true",
+	# help="black out names on scoreboard result images")
+	parser.add_argument("-o", required=False, action="store_true",
+						help="export all possible results to local files")
+	parser.add_argument("-i", dest="file", nargs=2, required=False,
+						help="upload local results. use `-i results.json overview.json`")
+	parser.add_argument("-f", dest="config", default="config.txt", required=False,
+						help="filename for config file. use `-f my_config.json`")
+	parser.add_argument("-t", required=False, action="store_true",
+						help="dry run for testing (won't post to stat.ink)")
+	return parser.parse_args()
+
+
 # CONFIG.TXT CREATION
-if getattr(sys, 'frozen', False): # place config.txt in same directory as script (bundled or not)
+CONFIG_FILE_NAME = parse_arguments().config
+if getattr(sys, 'frozen', False):  # place config.txt in same directory as script (bundled or not)
 	app_path = os.path.dirname(sys.executable)
 elif __file__:
 	app_path = os.path.dirname(__file__)
 else:
 	# No path to the script (probably can't happen) - just use the current directory
 	app_path = None
-config_path = "config.txt" if app_path is None else os.path.join(app_path, "config.txt")
+config_path = CONFIG_FILE_NAME if app_path is None else os.path.join(app_path, CONFIG_FILE_NAME)
 
 try:
 	config_file = open(config_path, "r")
@@ -1043,27 +1069,7 @@ def main():
 	check_for_updates()
 	check_statink_key()
 
-	# argparse stuff
-	################
-	parser = argparse.ArgumentParser()
-	srgroup = parser.add_mutually_exclusive_group()
-	parser.add_argument("-M", dest="N", required=False, nargs="?", action="store",
-		help="monitoring mode; pull data every N secs (default: 300)", const=300)
-	parser.add_argument("-r", required=False, action="store_true",
-		help="retroactively post unuploaded battles/jobs")
-	srgroup.add_argument("-nsr", required=False, action="store_true",
-						help="do not check for Salmon Run jobs")
-	srgroup.add_argument("-osr", required=False, action="store_true",
-						help="only check for Salmon Run jobs")
-	# parser.add_argument("--blackout", required=False, action="store_true",
-		# help="black out names on scoreboard result images")
-	parser.add_argument("-o", required=False, action="store_true",
-		help="export all possible results to local files")
-	parser.add_argument("-i", dest="file", nargs=2, required=False,
-		help="upload local results. use `-i results.json overview.json`")
-	parser.add_argument("-t", required=False, action="store_true",
-		help="dry run for testing (won't post to stat.ink)")
-	parser_result = parser.parse_args()
+	parser_result = parse_arguments()
 
 	# regular args
 	n_value     = parser_result.N

--- a/s3s.py
+++ b/s3s.py
@@ -12,6 +12,10 @@ A_VERSION = "0.1.6"
 
 DEBUG = False
 
+DEFAULT_USER_AGENT = 'Mozilla/5.0 (Linux; Android 11; Pixel 5) ' \
+		'AppleWebKit/537.36 (KHTML, like Gecko) ' \
+		'Chrome/94.0.4606.61 Mobile Safari/537.36'
+
 os.system("") # ANSI escape setup
 if sys.version_info[1] >= 7: # only works on python 3.7+
 	sys.stdout.reconfigure(encoding='utf-8') # note: please stop using git bash
@@ -48,12 +52,8 @@ SESSION_TOKEN = CONFIG_DATA["session_token"] # for nintendo login
 F_GEN_URL     = CONFIG_DATA["f_gen"]         # endpoint for generating f (imink API by default)
 
 # SET HTTP HEADERS
-if "app_user_agent" in CONFIG_DATA:
-	APP_USER_AGENT = str(CONFIG_DATA["app_user_agent"])
-else:
-	APP_USER_AGENT = 'Mozilla/5.0 (Linux; Android 11; Pixel 5) ' \
-		'AppleWebKit/537.36 (KHTML, like Gecko) ' \
-		'Chrome/94.0.4606.61 Mobile Safari/537.36'
+APP_USER_AGENT = str(CONFIG_DATA.get("app_user_agent", DEFAULT_USER_AGENT))
+
 
 def write_config(tokens):
 	'''Writes config file and updates the global variables.'''

--- a/utils.py
+++ b/utils.py
@@ -97,7 +97,7 @@ def gen_graphql_body(sha256hash, varname=None, varvalue=None):
 
 
 def custom_key_exists(key, config_data, value=True):
-	'''Checks if a given custom key exists in config.txt and is set to the specified value (true by default).'''
+	'''Checks if a given custom key exists in config_data (from config file) and is set to the specified value (true by default).'''
 
 	# https://github.com/frozenpandaman/s3s/wiki/config-keys
 	if key not in ["ignore_private", "app_user_agent", "force_uploads"]:


### PR DESCRIPTION
I want to upload stats for multiple people. Rather than making one checkout for each person, I added an option to choose the config file name.

I also fixed a few minor code problems: a missing parameter, an uninitialized variable, and a verbose expression of `dict.get(key, default)`.