### PR TITLE
fix setting rank when not S+

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -585,9 +585,9 @@ def prepare_battle_result(battle, ismonitoring, overview_data=None):
 					if child["id"] == battle["id"]: # found the battle ID in the other file
 
 						full_rank = re.split('([0-9]+)', child["udemae"].lower())
-						payload["rank_before"] = full_rank[0]
 						s_plus_before = len(full_rank) > 1 #True if "before" rank is s+
 						
+						payload["rank_before"] = full_rank[0]
 						if s_plus_before:
 							payload["rank_before_s_plus"] = int(full_rank[1])
 

--- a/s3s.py
+++ b/s3s.py
@@ -586,8 +586,12 @@ def prepare_battle_result(battle, ismonitoring, overview_data=None):
 
 						full_rank = re.split('([0-9]+)', child["udemae"].lower())
 						payload["rank_before"] = full_rank[0]
+		
 						if len(full_rank) > 1:
+							s_plus = True
 							payload["rank_before_s_plus"] = int(full_rank[1])
+						else:
+							s_plus = False
 
 						# anarchy battle (series) - not open
 						if "bankaraMatchChallenge" in parent and parent["bankaraMatchChallenge"] is not None:
@@ -603,7 +607,7 @@ def prepare_battle_result(battle, ismonitoring, overview_data=None):
 
 							if parent["bankaraMatchChallenge"]["udemaeAfter"] is None:
 								payload["rank_after"] = payload["rank_before"]
-								if payload["rank_before_s_plus"]:
+								if s_plus:
 									payload["rank_after_s_plus"] = payload["rank_before_s_plus"]
 							else:
 								if idx != 0:

--- a/s3s.py
+++ b/s3s.py
@@ -586,12 +586,10 @@ def prepare_battle_result(battle, ismonitoring, overview_data=None):
 
 						full_rank = re.split('([0-9]+)', child["udemae"].lower())
 						payload["rank_before"] = full_rank[0]
-		
-						if len(full_rank) > 1:
-							s_plus = True
+						s_plus_before = len(full_rank) > 1 #True if "before" rank is s+
+						
+						if s_plus_before:
 							payload["rank_before_s_plus"] = int(full_rank[1])
-						else:
-							s_plus = False
 
 						# anarchy battle (series) - not open
 						if "bankaraMatchChallenge" in parent and parent["bankaraMatchChallenge"] is not None:
@@ -607,7 +605,7 @@ def prepare_battle_result(battle, ismonitoring, overview_data=None):
 
 							if parent["bankaraMatchChallenge"]["udemaeAfter"] is None:
 								payload["rank_after"] = payload["rank_before"]
-								if s_plus:
+								if s_plus_before:
 									payload["rank_after_s_plus"] = payload["rank_before_s_plus"]
 							else:
 								if idx != 0:


### PR DESCRIPTION
should fix #58. 

payload["rank_before_s_plus"] doesnt exist when the player is not S+, an oversight on my end. Instead we can just check an s_plus bool