### PR TITLE
Fix base64 import omissions.

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -4,7 +4,7 @@
 # https://github.com/frozenpandaman/s3s
 # License: GPLv3
 
-import argparse, datetime, json, os, shutil, re, requests, sys, time, uuid
+import argparse, datetime, json, os, shutil, re, requests, sys, time, uuid, base64
 import msgpack
 from packaging import version
 import iksm, utils


### PR DESCRIPTION
When I run the latest version of s3s with the `-r -M` option, I get the following error:
```
Traceback (most recent call last):
  File "C:\Users\Admin\Source\Repos\s3s\s3s.py", line 1382, in <module>
    main()
  File "C:\Users\Admin\Source\Repos\s3s\s3s.py", line 1354, in main
    check_if_missing(which, True if secs != -1 else False, blackout, test_run)
  File "C:\Users\Admin\Source\Repos\s3s\s3s.py", line 1017, in check_if_missing
    fetch_and_upload_single_result(id, noun, ismonitoring, isblackout, istestrun)
  File "C:\Users\Admin\Source\Repos\s3s\s3s.py", line 966, in fetch_and_upload_single_result
    post_result(result, ismonitoring, isblackout, istestrun)
  File "C:\Users\Admin\Source\Repos\s3s\s3s.py", line 790, in post_result
    payload = prepare_battle_result(results[i]["data"], ismonitoring, isblackout, overview_data)
  File "C:\Users\Admin\Source\Repos\s3s\s3s.py", line 623, in prepare_battle_result
    battle_id = base64.b64decode(battle["id"]).decode('utf-8')
NameError: name 'base64' is not defined
```

It seems to be a simple forgetting to import the base64 module.