### PR TITLE
Don't use SquidProgress when non-interactive

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -1197,17 +1197,19 @@ class SquidProgress:
 		self.count = 0
 
 	def __call__(self):
-		lineend = shutil.get_terminal_size()[0] - 5 # 5 = ('>=> ' or '===>') + blank 1
-		ika = '>=> ' if self.count % 2 == 0 else '===>'
-		sys.stdout.write(f"\r{' '*self.count}{ika}{' '*(lineend - self.count)}")
-		sys.stdout.flush()
-		self.count += 1
-		if self.count > lineend:
-			self.count = 0
+		if sys.stdout.isatty():
+			lineend = shutil.get_terminal_size()[0] - 5 # 5 = ('>=> ' or '===>') + blank 1
+			ika = '>=> ' if self.count % 2 == 0 else '===>'
+			sys.stdout.write(f"\r{' '*self.count}{ika}{' '*(lineend - self.count)}")
+			sys.stdout.flush()
+			self.count += 1
+			if self.count > lineend:
+				self.count = 0
 
 	def __del__(self):
-		sys.stdout.write(f"\r{' '*(shutil.get_terminal_size()[0] - 1)}\r")
-		sys.stdout.flush()
+		if sys.stdout.isatty():
+			sys.stdout.write(f"\r{' '*(shutil.get_terminal_size()[0] - 1)}\r")
+			sys.stdout.flush()
 
 
 def export_seed_json(skipprefetch=False):

--- a/s3s.py
+++ b/s3s.py
@@ -1124,10 +1124,12 @@ def monitor_battles(which, secs, isblackout, istestrun, skipprefetch):
 	try:
 		while True:
 			for i in range(secs, -1, -1):
-				sys.stdout.write(f"Press Ctrl+C to exit. {i} ")
-				sys.stdout.flush()
+				if sys.stdout.isatty():
+					sys.stdout.write(f"Press Ctrl+C to exit. {i} ")
+					sys.stdout.flush()
 				time.sleep(1)
-				sys.stdout.write("\r")
+				if sys.stdout.isatty():
+					sys.stdout.write("\r")
 
 			print("Checking for new results...", end='\r')
 			input_params = [


### PR DESCRIPTION
Hides the SquidProgress animation if s3s is not running in an interactive terminal, as it will likely not display properly, offsetting text or wrapping the output incorrectly.

Works on Linux, haven't tested on Windows but it *should* work according to python docs.