### PR TITLE
Add Docker support to more easly deploy s3s

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/.git
+**/.github
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+# Install python 3 dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project
+COPY . .
+
+# Create dummy config file
+RUN touch config.txt
+
+# Run s3s in monitoring mode and checks for & uploads any battles/jobs present on SplatNet 3 that haven't yet been uploaded.
+CMD [ "python", "./s3s.py", "-M", "-r" ]


### PR DESCRIPTION
***Hoi***

I really like and appreciate to use this project to track all my match on Stat.ink but I was always annoyed for the installation process and update. *(Create a cron or Daemon was never for me my favorite part)*

***But today I want share an Alternative methods to setup this project using Docker.***

This simple pull request only add two file to this project for now.

 - a simple `Dockerfile` who start from the official python3 image and install decencies to finally start s3s in monitoring mode.
 - a `.dockerignore` to not copy the `.git` folder and so prevent update inside the running Container *(Cause update must be manage by different Docker image for container)*.

I don't have updated yet the `Readme.md` file to had simple docker commands to manage the container cause I'm not sure if this pull request will be merge or not but for now I post these commands here.

Build and create the docker Image "s3s" from source code.
```bash
docker build -t s3s:latest .
```

Create a dummy file `config.txt` to mount for container *(otherwise docker create a folder)*.
```bash
touch config.txt
```

Run the container in an interactive mode for first time configuration
```bash
docker run --name s3s -v $(pwd)/config.txt:/usr/src/app/config.txt --rm -it s3s
```

Run docker container in background
```bash
docker run --name s3s -v $(pwd)/config.txt:/usr/src/app/config.txt -d s3s
```

Just to finish I know this unofficial Docker project exist https://hub.docker.com/r/isseim/s3s
But I think it would be great to have a true official Docker support and maybe later have a dedicated github action to automatically deploy latest release of this project.

Well thanks to have take time to read all of this and I hope to had some response quick for the things I need to do or not if you like my idea of official docker support.

**Stay fresh**.