### PR TITLE
Remove `fail_reason` from Salmon Run payload

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -769,13 +769,6 @@ def prepare_job_result(job, ismonitoring, isblackout, overview_data=None):
 	if payload["clear_waves"] < 0: # player dc'd
 		payload["clear_waves"] = None
 
-	elif payload["clear_waves"] != 3: # job defeat only
-		underperformed = False
-		for wave in job["waveResults"]:
-			if wave["teamDeliverCount"] < wave["deliverNorm"]:
-				underperformed = True
-		payload["fail_reason"] = "time_limit" if underperformed else "wipe_out"
-
 	# xtrawave only
 	# https://stat.ink/api-info/boss-salmonid3
 	if job["bossResult"]:

--- a/s3s.py
+++ b/s3s.py
@@ -11,7 +11,7 @@ import msgpack
 from packaging import version
 import iksm, utils
 
-A_VERSION = "0.2.0"
+A_VERSION = "0.2.2"
 
 DEBUG = False
 
@@ -768,6 +768,11 @@ def prepare_job_result(job, ismonitoring, isblackout, overview_data=None):
 
 	if payload["clear_waves"] < 0: # player dc'd
 		payload["clear_waves"] = None
+
+	elif payload["clear_waves"] != 3: # job failure
+		last_wave = job["waveResults"][payload["clear_waves"]]
+		if last_wave["teamDeliverCount"] >= last_wave["deliverNorm"]: # delivered more than quota, but still failed
+			payload["fail_reason"] = "wipe_out"
 
 	# xtrawave only
 	# https://stat.ink/api-info/boss-salmonid3


### PR DESCRIPTION
#82 

This PR removes the code related to fail_reason.
We have an alternative that is to send it only when the wipe_out is confirmed.

"Alternative way" will be like this (not tested):
```diff
diff --git a/s3s.py b/s3s.py
index 6c6668c..c524058 100755
--- a/s3s.py
+++ b/s3s.py
@@ -770,11 +770,9 @@ def prepare_job_result(job, ismonitoring, isblackout, overview_data=None):
                payload["clear_waves"] = None

        elif payload["clear_waves"] != 3: # job defeat only
-               underperformed = False
-               for wave in job["waveResults"]:
-                       if wave["teamDeliverCount"] < wave["deliverNorm"]:
-                               underperformed = True
-               payload["fail_reason"] = "time_limit" if underperformed else "wipe_out"
+               wave = job["waveResults"][payload["clear_waves"]]
+               if wave["teamDeliverCount"] >= wave["deliverNorm"]:
+                       payload["fail_reason"] = "wipe_out"

        # xtrawave only
        # https://stat.ink/api-info/boss-salmonid3
```

FYI, s3si.ts implements "alternative way": https://github.com/spacemeowx2/s3si.ts/blob/707d7204dc7849ad8f60af89d7af627e67c533d5/src/exporters/stat.ink.ts#L659-L666
