### PR TITLE
Use statink new uuid-list option to reduce "battle already uploaded"

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -1412,7 +1412,7 @@ def check_if_missing(which, isblackout, istestrun, skipprefetch):
 	# https://github.com/fetus-hina/stat.ink/wiki/Spl3-API:-Battle-%EF%BC%8D-Get-UUID-List-(for-s3s)
 	# https://github.com/fetus-hina/stat.ink/wiki/Spl3-API:-Salmon-%EF%BC%8D-Get-UUID-List
 	if which in ("both", "ink"):
-		urls.append("https://stat.ink/api/v3/s3s/uuid-list") # max 200 entries
+		urls.append("https://stat.ink/api/v3/s3s/uuid-list?lobby=adaptive") # max 200 entries
 	else:
 		urls.append(None)
 	if which in ("both", "salmon"):
@@ -1944,7 +1944,7 @@ def main():
 
 		# only upload unuploaded results
 		auth = {'Authorization': f'Bearer {API_KEY}'}
-		resp_b = requests.get("https://stat.ink/api/v3/s3s/uuid-list", headers=auth)
+		resp_b = requests.get("https://stat.ink/api/v3/s3s/uuid-list?lobby=adaptive", headers=auth)
 		resp_j = requests.get("https://stat.ink/api/v3/salmon/uuid-list", headers=auth)
 		try:
 			statink_uploads = json.loads(resp_b.text)


### PR DESCRIPTION
Fix #111, another version of #116

The new `lobby=adaptive` option should match the data available from SplatNet.
The remote call is made only once, so it is clearer and faster than the code in #116.

[What it is doing is no different than the PR.](https://github.com/fetus-hina/stat.ink/blob/a416230c33ce3593a85c0313beaf17d06c8d6d8c/actions/api/v3/s3s/UuidListAction.php#L66-L84)