### PR TITLE
Add Korean tutorial link to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ s3s 🦑
 
 (ja) 日本語版セットアップ手順は[こちら](https://nerune-jp.com/splatoon3-statink/)、または[こちら](https://vanillasalt.net/2022/10/10/how-to-use-s3s/)。
 
+(ko) 한국어 가이드는 [여기](https://github.com/cake-monotone/s3s)를 참조해 주세요.
+
 Looking to track your _Splatoon 2_ gameplay? See **[splatnet2statink](https://github.com/frozenpandaman/splatnet2statink)**.
 
 ### Features


### PR DESCRIPTION
Hi! I'm twitter:@splatp_on

As we discussed on Twitter, I've added the Korean tutorial link to the README.

As you said, wiki uploads are a great way, but I think it's hard to manage image file delivery and typo fixes, so I've forked the repository so you can manage your repo more seamlessly! 🙂 