### PR TITLE
(hopefully) fix crash upon tokens expiring

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -252,20 +252,7 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 				data=utils.gen_graphql_body(sha),
 				headers=headbutt(forcelang=lang),
 				cookies=dict(_gtoken=GTOKEN))
-			try: query1_resp = json.loads(query1.text)
-			except json.decoder.JSONDecodeError or query1.status_code != 200: # fallback for expired tokens and nintendo being bad
-				print("\nYour tokens have likely expired. Attempting to regenerate them...")
-				prefetch_checks()
-				query1 = requests.post(utils.GRAPHQL_URL,
-					data=utils.gen_graphql_body(sha),
-					headers=headbutt(forcelang=lang),
-					cookies=dict(_gtoken=GTOKEN))
-				if query1.status_code != 200: 
-					print("\nSomething's wrong with one of the query hashes. Ensure s3s is up-to-date, and if this message persists, please open an issue on GitHub.")
-					if DEBUG:
-						print(f"* status_code = {query1.status_code}\n{query1.text}")
-					sys.exit(1)
-				query1_resp = json.loads(query1.text)
+			query1_resp = json.loads(query1.text)
 			swim()
 
 			if not query1_resp.get("data"): # catch error
@@ -2052,9 +2039,6 @@ def main():
 		update_salmon_profile()
 
 	if check_old:
-		if which == "both":
-			prefetch_checks(printout=True)
-			skipprefetch = True
 		check_if_missing(which, blackout, test_run, skipprefetch) # monitoring mode hasn't begun yet
 		print()
 

--- a/s3s.py
+++ b/s3s.py
@@ -252,7 +252,20 @@ def fetch_json(which, separate=False, exportall=False, specific=False, numbers_o
 				data=utils.gen_graphql_body(sha),
 				headers=headbutt(forcelang=lang),
 				cookies=dict(_gtoken=GTOKEN))
-			query1_resp = json.loads(query1.text)
+			try: query1_resp = json.loads(query1.text)
+			except json.decoder.JSONDecodeError or query1.status_code != 200: # fallback for expired tokens and nintendo being bad
+				print("\nYour tokens have likely expired. Attempting to regenerate them...")
+				prefetch_checks()
+				query1 = requests.post(utils.GRAPHQL_URL,
+					data=utils.gen_graphql_body(sha),
+					headers=headbutt(forcelang=lang),
+					cookies=dict(_gtoken=GTOKEN))
+				if query1.status_code != 200: 
+					print("\nSomething's wrong with one of the query hashes. Ensure s3s is up-to-date, and if this message persists, please open an issue on GitHub.")
+					if DEBUG:
+						print(f"* status_code = {query1.status_code}\n{query1.text}")
+					sys.exit(1)
+				query1_resp = json.loads(query1.text)
 			swim()
 
 			if not query1_resp.get("data"): # catch error


### PR DESCRIPTION
Currently, s3s sometimes throws a `json.decoder.JSONDecodeError` whenever the tokens have expired while using both `-M [n]` and `-r`  This should hopefully fix it, allowing for continuous usage with little (to no) restarts :D