### PR TITLE
add new specials in salmon run

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -999,7 +999,9 @@ def prepare_job_result(job, ismonitoring, isblackout, overview_data=None, prevre
 		20010: "jetpack",
 		20012: "kanitank",
 		20013: "sameride",
-		20014: "tripletornado"
+		20014: "tripletornado",
+                20017: "teioika",
+                20018: "ultra_chakuchi"
 	}
 
 	players = []
@@ -1130,6 +1132,8 @@ def prepare_job_result(job, ismonitoring, isblackout, overview_data=None, prevre
 			"kanitank": 0,
 			"sameride": 0,
 			"tripletornado": 0,
+                        "teioika": 0,
+                        "ultra_chakuchi": 0,
 			"unknown": 0
 		}
 		for wep_use in wave["specialWeapons"]:

--- a/s3s.py
+++ b/s3s.py
@@ -1000,8 +1000,8 @@ def prepare_job_result(job, ismonitoring, isblackout, overview_data=None, prevre
 		20012: "kanitank",
 		20013: "sameride",
 		20014: "tripletornado",
-                20017: "teioika",
-                20018: "ultra_chakuchi"
+		20017: "teioika",
+		20018: "ultra_chakuchi"
 	}
 
 	players = []
@@ -1132,8 +1132,8 @@ def prepare_job_result(job, ismonitoring, isblackout, overview_data=None, prevre
 			"kanitank": 0,
 			"sameride": 0,
 			"tripletornado": 0,
-                        "teioika": 0,
-                        "ultra_chakuchi": 0,
+			"teioika": 0,
+			"ultra_chakuchi": 0,
 			"unknown": 0
 		}
 		for wep_use in wave["specialWeapons"]:


### PR DESCRIPTION
Added teioika (kraken royale) and ultra_chakuchi (triple splashdown) to specials in salmon run.

I tested on my account and found that stat.ink already accepts these new specials
- API info: https://stat.ink/api-info/weapon3
- uploaded salmon run results:
  - teioika example: https://stat.ink/@gecko655/salmon3/889db975-3c90-4f7d-9192-b84386d5310d
  - ultra_chakuchi example: https://stat.ink/@gecko655/salmon3/1fdff2b6-2feb-4a86-96c7-a20ad391e0cf

Fixes: https://github.com/fetus-hina/stat.ink/issues/1258