### PR TITLE
Stop circular import in iksm.py

### DIFF
--- a/iksm.py
+++ b/iksm.py
@@ -37,11 +37,14 @@ def get_nsoapp_version():
 	if NSOAPP_VERSION != "unknown": # already set
 		return NSOAPP_VERSION
 	else:
-		# We should have a S3S_VERSION and F_GEN_URL already (from log_in or get_gtoken).
-		# Let's check it before send actual request to f generation API...
-		global S3S_VERSION, F_GEN_URL
-		assert S3S_VERSION != "unknown"
-		assert F_GEN_URL != "unknown"
+		# should exist already - from log_in() or get_gtoken() - but check to make sure
+		try:
+			global S3S_VERSION, F_GEN_URL
+			assert S3S_VERSION != "unknown"
+			assert F_GEN_URL != "unknown"
+		except AssertionError:
+			print("Cannot determine s3s version or f generation API.")
+			sys.exit(1)
 
 		try: # try to get NSO version from f API
 			f_conf_url = os.path.dirname(F_GEN_URL) + "/config" # default endpoint for imink API

--- a/iksm.py
+++ b/iksm.py
@@ -5,8 +5,6 @@
 import base64, hashlib, json, os, re, sys, urllib
 import requests
 from bs4 import BeautifulSoup
-from s3s import F_GEN_URL as f_gen_url
-from s3s import A_VERSION as s3s_ver
 
 USE_OLD_NSOAPP_VER    = False # Change this to True if you're getting a "9403: Invalid token." error
 
@@ -17,6 +15,7 @@ WEB_VIEW_VERSION      = "unknown"
 WEB_VIEW_VER_FALLBACK = "6.0.0-eb33aadc" # fallback for current splatnet 3 ver
 SPLATNET3_URL         = "https://api.lp1.av5ja.srv.nintendo.net"
 GRAPHQL_URL           = SPLATNET3_URL + "/api/graphql"
+F_GEN_URL             = "unknown"
 
 # functions in this file & call stack:
 # - get_nsoapp_version()
@@ -38,9 +37,15 @@ def get_nsoapp_version():
 	if NSOAPP_VERSION != "unknown": # already set
 		return NSOAPP_VERSION
 	else:
+		# We should have a S3S_VERSION and F_GEN_URL already (from log_in or get_gtoken).
+		# Let's check it before send actual request to f generation API...
+		global S3S_VERSION, F_GEN_URL
+		assert S3S_VERSION != "unknown"
+		assert F_GEN_URL != "unknown"
+
 		try: # try to get NSO version from f API
-			f_conf_url = os.path.dirname(f_gen_url) + "/config" # default endpoint for imink API
-			f_conf_header = {'User-Agent': f's3s/{s3s_ver}'}
+			f_conf_url = os.path.dirname(F_GEN_URL) + "/config" # default endpoint for imink API
+			f_conf_header = {'User-Agent': f's3s/{S3S_VERSION}'}
 			f_conf_rsp = requests.get(f_conf_url, headers=f_conf_header)
 			f_conf_json = json.loads(f_conf_rsp.text)
 			ver = f_conf_json["nso_version"]
@@ -140,11 +145,12 @@ def get_web_view_ver(bhead=[], gtoken=""):
 		return WEB_VIEW_VERSION
 
 
-def log_in(ver, app_user_agent):
+def log_in(ver, app_user_agent, f_gen_url):
 	'''Logs in to a Nintendo Account and returns a session_token.'''
 
-	global S3S_VERSION
+	global S3S_VERSION, F_GEN_URL
 	S3S_VERSION = ver
+	F_GEN_URL = f_gen_url
 
 	auth_state = base64.urlsafe_b64encode(os.urandom(36))
 
@@ -235,10 +241,11 @@ def get_session_token(session_token_code, auth_code_verifier):
 def get_gtoken(f_gen_url, session_token, ver):
 	'''Provided the session_token, returns a GameWebToken JWT and account info.'''
 
-	nsoapp_version = get_nsoapp_version()
-
-	global S3S_VERSION
+	global S3S_VERSION, F_GEN_URL
 	S3S_VERSION = ver
+	F_GEN_URL = f_gen_url
+
+	nsoapp_version = get_nsoapp_version()
 
 	app_head = {
 		'Host':            'accounts.nintendo.com',

--- a/s3s.py
+++ b/s3s.py
@@ -148,7 +148,7 @@ def gen_new_tokens(reason, force=False):
 
 	if SESSION_TOKEN == "":
 		print("Please log in to your Nintendo Account to obtain your session_token.")
-		new_token = iksm.log_in(A_VERSION, APP_USER_AGENT)
+		new_token = iksm.log_in(A_VERSION, APP_USER_AGENT, F_GEN_URL)
 		if new_token is None:
 			print("There was a problem logging you in. Please try again later.")
 		elif new_token == "skip":


### PR DESCRIPTION
starting from https://github.com/frozenpandaman/s3s/commit/a4785322a8ac9ba23224b7010eaf519e0b1e96e7, s3s contains a circular import.

which causes s3s no longer able to import from another module (like my [s3splus](https://github.com/rinsuki/s3splus)):

```
Traceback (most recent call last):
  File "/Users/user/work/github.com/rinsuki/s3splus/main.py", line 13, in <module>
    from plus.utils import PLUS_VERSION
  File "/Users/user/work/github.com/rinsuki/s3splus/plus/utils.py", line 9, in <module>
    from s3sproxy import A_VERSION
  File "/Users/user/work/github.com/rinsuki/s3splus/s3sproxy.py", line 6, in <module>
    from s3s import A_VERSION
  File "/Users/user/work/github.com/rinsuki/s3splus/s3s/s3s.py", line 12, in <module>
    import iksm, utils
  File "/Users/user/work/github.com/rinsuki/s3splus/s3s/iksm.py", line 8, in <module>
    from s3s import F_GEN_URL as f_gen_url
ImportError: cannot import name 'F_GEN_URL' from partially initialized module 's3s' (most likely due to a circular import) (/Users/user/work/github.com/rinsuki/s3splus/s3s/s3s.py)
```

so I fixed it.

#### Note

I'm actually not using the f API way, so could you try it with two pass (run with/without session_token) before merge it...?