### PR TITLE
Fix uninitialized variables in posting battle result with empty overview data

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -679,6 +679,7 @@ def prepare_battle_result(battle, ismonitoring, isblackout, overview_data=None):
 				overview_data = None
 				print("Failed to get recent Anarchy Battles. Proceeding without information on current rank.")
 		if overview_data is not None:
+			ranked_list = []
 			for screen in overview_data:
 				if "bankaraBattleHistories" in screen["data"]:
 					ranked_list = screen["data"]["bankaraBattleHistories"]["historyGroups"]["nodes"]
@@ -766,6 +767,7 @@ def prepare_battle_result(battle, ismonitoring, isblackout, overview_data=None):
 				overview_data = None
 				print("Failed to get recent X Battles. Proceeding without some information on X Power.")
 		if overview_data is not None:
+			x_list = []
 			for screen in overview_data:
 				if "xBattleHistories" in screen["data"]:
 					x_list = screen["data"]["xBattleHistories"]["historyGroups"]["nodes"]


### PR DESCRIPTION
When uploading local data with empty overview file, `ranked_list` and `x_list` may be left uninitialized, causing the result fails to be uploaded.
