### PR TITLE
Use "rengo" keyword to upload triumvirate "オカシラ連合" salmonrun result

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -885,6 +885,8 @@ def prepare_job_result(job, ismonitoring, isblackout, overview_data=None, prevre
 	if job["bossResult"]:
 		try:
 			payload["king_salmonid"] = utils.b64d(job["bossResult"]["boss"]["id"])
+			if payload["king_salmonid"] == 30:
+				payload["king_salmonid"] = "rengo"
 		except KeyError:
 			print("Could not send unsupported King Salmonid data to stat.ink. You may want to delete & re-upload this job later.")
 


### PR DESCRIPTION
At this moment, stat.ink accepts ID `26` as triumvirate but actually Splanet3 returns it as ID `30`.

In the meantime until stat.ink is fixed, this PR make s3s send the result of triumvirate via its alias "rengo".

As this is urgent patch until the fix of stat.ink, it does not need to be merged. I made this patch just in case the s3s users _in a hurry_ want to use it.

- Tested on my account: https://stat.ink/@gecko655/salmon3/cc0f8177-4e70-496d-8d3a-b07925451de6
- I wanted to send a patch to stat.ink too, but I don't think I can set up php on my environment to create the DB migration files, so I created this. :innocent: