### PR TITLE
Change imink API with nxapi-znca-api

### DIFF
--- a/iksm.py
+++ b/iksm.py
@@ -5,6 +5,7 @@
 import base64, hashlib, json, os, re, sys, urllib
 import requests
 from bs4 import BeautifulSoup
+from packaging import version
 
 USE_OLD_NSOAPP_VER    = False # Change this to True if you're getting a "9403: Invalid token." error
 
@@ -55,6 +56,10 @@ def get_nsoapp_version():
 			ver = f_conf_json["nso_version"]
 
 			NSOAPP_VERSION = ver
+
+			if version.parse(NSOAPP_VERSION) < version.parse(NSOAPP_SUPPORTED):
+				print("f generation API is outdated! check config.txt and change f_gen that supports NSO version >= 2.12.0")
+				sys.exit(1)
 
 			return NSOAPP_VERSION
 		except: # fallback to apple app store

--- a/iksm.py
+++ b/iksm.py
@@ -10,7 +10,8 @@ USE_OLD_NSOAPP_VER    = False # Change this to True if you're getting a "9403: I
 
 S3S_VERSION           = "unknown"
 NSOAPP_VERSION        = "unknown"
-NSOAPP_VER_FALLBACK   = "2.10.1"
+NSOAPP_SUPPORTED      = "2.12.0"
+NSOAPP_VER_FALLBACK   = NSOAPP_SUPPORTED
 WEB_VIEW_VERSION      = "unknown"
 WEB_VIEW_VER_FALLBACK = "6.0.0-30a1464a" # fallback for current splatnet 3 ver
 SPLATNET3_URL         = "https://api.lp1.av5ja.srv.nintendo.net"
@@ -478,7 +479,7 @@ def call_f_api(access_token, step, f_gen_url, user_id, coral_user_id=None):
 			'Content-Type':    'application/json; charset=utf-8',
 			'X-znca-Platform': 'Android',
 			'X-znca-Version':  nsoapp_version,
-			'X-znca-Client-Version': nsoapp_version
+			'X-znca-Client-Version': NSOAPP_SUPPORTED
 		}
 		api_body = { # 'timestamp' & 'request_id' (uuid v4) set automatically
 			'token':       access_token,

--- a/iksm.py
+++ b/iksm.py
@@ -47,7 +47,7 @@ def get_nsoapp_version():
 			sys.exit(1)
 
 		try: # try to get NSO version from f API
-			f_conf_url = os.path.dirname(F_GEN_URL) + "/config" # default endpoint for imink API
+			f_conf_url = os.path.dirname(F_GEN_URL) + "/config" # default endpoint for imink API but also works with nxapi-znca-api
 			f_conf_header = {'User-Agent': f's3s/{S3S_VERSION}'}
 			f_conf_rsp = requests.get(f_conf_url, headers=f_conf_header)
 			f_conf_json = json.loads(f_conf_rsp.text)
@@ -477,7 +477,8 @@ def call_f_api(access_token, step, f_gen_url, user_id, coral_user_id=None):
 			'User-Agent':      f's3s/{S3S_VERSION}',
 			'Content-Type':    'application/json; charset=utf-8',
 			'X-znca-Platform': 'Android',
-			'X-znca-Version':  nsoapp_version
+			'X-znca-Version':  nsoapp_version,
+			'X-znca-Client-Version': nsoapp_version
 		}
 		api_body = { # 'timestamp' & 'request_id' (uuid v4) set automatically
 			'token':       access_token,

--- a/s3s.py
+++ b/s3s.py
@@ -32,7 +32,7 @@ try:
 	config_file.close()
 except (IOError, ValueError):
 	print("Generating new config file.")
-	CONFIG_DATA = {"api_key": "", "acc_loc": "", "gtoken": "", "bullettoken": "", "session_token": "", "f_gen": "https://api.imink.app/f"}
+	CONFIG_DATA = {"api_key": "", "acc_loc": "", "gtoken": "", "bullettoken": "", "session_token": "", "f_gen": "https://nxapi-znca-api.fancy.org.uk/api/znca"}
 	config_file = open(config_path, "w")
 	config_file.seek(0)
 	config_file.write(json.dumps(CONFIG_DATA, indent=4, sort_keys=False, separators=(',', ': ')))
@@ -48,7 +48,7 @@ USER_COUNTRY  = CONFIG_DATA["acc_loc"][-2:]  # nintendo account info
 GTOKEN        = CONFIG_DATA["gtoken"]        # for accessing splatnet - base64 json web token
 BULLETTOKEN   = CONFIG_DATA["bullettoken"]   # for accessing splatnet - base64
 SESSION_TOKEN = CONFIG_DATA["session_token"] # for nintendo login
-F_GEN_URL     = CONFIG_DATA["f_gen"]         # endpoint for generating f (imink API by default)
+F_GEN_URL     = CONFIG_DATA["f_gen"]         # endpoint for generating f (nxapi-znca-api by default)
 
 thread_pool = ThreadPoolExecutor(max_workers=2)
 

--- a/s3s.py
+++ b/s3s.py
@@ -32,7 +32,7 @@ try:
 	config_file.close()
 except (IOError, ValueError):
 	print("Generating new config file.")
-	CONFIG_DATA = {"api_key": "", "acc_loc": "", "gtoken": "", "bullettoken": "", "session_token": "", "f_gen": "https://nxapi-znca-api.fancy.org.uk/api/znca"}
+	CONFIG_DATA = {"api_key": "", "acc_loc": "", "gtoken": "", "bullettoken": "", "session_token": "", "f_gen": "https://nxapi-znca-api.fancy.org.uk/api/znca/f"}
 	config_file = open(config_path, "w")
 	config_file.seek(0)
 	config_file.write(json.dumps(CONFIG_DATA, indent=4, sort_keys=False, separators=(',', ': ')))


### PR DESCRIPTION
nxapi-znca-api now supports NSO app 2.12.0(public test)
server is bit unstable, so request might fail for now

so I just changed default API to nxapi-znca-api

I also added for outdated NSO app check(as NSO app version < 2.12.0 will not work), and added hardcorded X-znca-Client-Version header.