### PR TITLE
Add command line argument which disables automatic token refresh

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -1830,8 +1830,7 @@ def main():
 	outfile      = parser_result.o            # output to local files
 	skipprefetch = parser_result.skipprefetch # skip prefetch checks to ensure token validity
 
-	global DISABLE_REFRESH_RC
-	DISABLE_REFRESH_RC = parser_result.RC # stop application instead of trying to refresh tokens
+	rc_value = parser_result.RC # stop application instead of trying to refresh tokens
 
 	# setup
 	#######
@@ -1871,6 +1870,18 @@ def main():
 		elif secs < 60:
 			print("Minimum number of seconds in monitoring mode is 60. Exiting.")
 			sys.exit(0)
+
+	global DISABLE_REFRESH_RC
+	DISABLE_REFRESH_RC = None
+	if rc_value is not None:
+		try:
+			DISABLE_REFRESH_RC = int(rc_value)
+		except ValueError:
+			print("Number provided for --norefresh must be an integer. Exiting.")
+			sys.exit(1)
+		if DISABLE_REFRESH_RC < 0:
+			print("RC for --norefresh must be 0 or positive! Exiting.")
+			sys.exit(1)
 
 	# export results to file: -o flag
 	#################################


### PR DESCRIPTION
Hi eli,

on June 13th I helped someone with a new method to obtain the gToken in the #s3s channel on the APIs discord. Back then you asked me to provide instructions on an issue here in the repo. 

I decided to publicly release the repo + automated scripts instead. This is mostly due to the manual method requiring a lot of steps, making it a quite annoying and tedious task.

To make the automated method as accessible as possible, I've written a wrapper script which basically "envelops" s3s in a way that it runs s3s normally but steps in everytime s3s stumbles across invalid tokens. It would then automatically refresh the tokens using an emulator, store them in config.txt and call s3s again which can now work properly.

---

I need one last thing before I can publish my repo which is the possibility to disable s3s's token refresh entirely so that my script gets one of 3 distinct outputs to react to:
1. `RC 0` = tokens valid, no other errors in s3s -> successful run
2. `RC 1` = other errors in s3s, for example 500 from SplatNet -> stop the execution
3. `RC [2 or something else]` = tokens are not valid, s3s exited without attempting to refresh them -> not a "real" error, refresh and retry

This PR contains the changes necessary to add this behavior without changing the default behavior of s3s:
- add a command line arg `--norefresh [RC]` which makes s3s exit instead of attempting to refresh tokens
- `[RC]` is the return code of the script for this specific situation. It is optional and defaults to 0 (no error) if left empty.
- if the user does not add the `--norefresh` arg to command line, s3s behaves exactly as it did before this pull request

---

I know you want to keep this repo as simple as possible but the change is small and doesn't really affect anyone either.

I hope this PR is acceptable. :smile:   
If anything is missing / bad, please let me know and I'll fix it.