### PR TITLE
Small Bugfix: evaluate --norefresh arg before switching to the --getseed method instead of after

### DIFF
--- a/s3s.py
+++ b/s3s.py
@@ -1844,6 +1844,18 @@ def main():
 		check_statink_key()
 	set_language()
 
+	global DISABLE_REFRESH_RC
+	DISABLE_REFRESH_RC = None
+	if rc_value is not None:
+		try:
+			DISABLE_REFRESH_RC = int(rc_value)
+		except ValueError:
+			print("Number provided for --norefresh must be an integer. Exiting.")
+			sys.exit(1)
+		if DISABLE_REFRESH_RC < 0:
+			print("RC for --norefresh must be 0 or positive! Exiting.")
+			sys.exit(1)
+
 	# i/o checks
 	############
 	if getseed and any(re.search("^(--getseed|--skipprefetch|--norefresh|[0-9]+)$", arg) is None for arg in sys.argv[1:]):
@@ -1875,18 +1887,6 @@ def main():
 		elif secs < 60:
 			print("Minimum number of seconds in monitoring mode is 60. Exiting.")
 			sys.exit(0)
-
-	global DISABLE_REFRESH_RC
-	DISABLE_REFRESH_RC = None
-	if rc_value is not None:
-		try:
-			DISABLE_REFRESH_RC = int(rc_value)
-		except ValueError:
-			print("Number provided for --norefresh must be an integer. Exiting.")
-			sys.exit(1)
-		if DISABLE_REFRESH_RC < 0:
-			print("RC for --norefresh must be 0 or positive! Exiting.")
-			sys.exit(1)
 
 	# export results to file: -o flag
 	#################################


### PR DESCRIPTION
(related to #213)

Hi eli,

I found a bug with the `--norefresh` arg. s3s fails with an error whenever it gets called with `--getseed` because `--norefresh` gets loaded AFTER `--getseed` branches away to the file export.

I've moved the `--norefresh` evaluation 20 lines up (before `--getseed` branches away) and now everything should work fine.

I didn't notice this bug in tests earlier because I usually tested the stat.ink integration first and always had a valid token whenever I tested `--getseed`,  my bad!

Sorry for the inconvenience!