### PR TITLE
fix: add missing dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
 beautifulsoup4
+certifi
+charset-normalizer
+idna
 msgpack_python
 packaging
 pymmh3
 requests
+soupsieve
+typing_extensions
+urllib3


### PR DESCRIPTION
Missing dependencies in `requirements.txt` caused `s3s.py -r` to fail in fresh environments.

**Verification Process:**
1. Created a clean virtual environment: `uv venv --python 3.14`
2. Installed dependencies: `uv pip sync requirements.txt`
3. Executed the script: `python s3s.py -r` (Failed with `ModuleNotFoundError`)
4. Added missing packages to `requirements.txt` and re-synced.
5. Re-executed the script (Successfully running).